### PR TITLE
Remove Behat/Transliterator dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,10 @@ php:
   - '7.1'
 
 env:
-  - COMPOSER_UPDATE=
-  - COMPOSER_UPDATE=--prefer-lowest
+
+before_install:
+  - ls -la /home/travis/.phpenv/versions/*/etc/conf.d/
+  - php -i
 
 script:
   - composer update $COMPOSER_UPDATE -n

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
   },
   "require": {
     "php": ">= 5.6",
+    "ext-intl": ">= 2.0",
     "psr/http-message": "^1.0",
-    "behat/transliterator": "^1.2",
     "psr/log": "^1.0"
   },
   "require-dev": {

--- a/src/Bucket/Plain.php
+++ b/src/Bucket/Plain.php
@@ -1,7 +1,6 @@
 <?php
 namespace HelloFresh\Stats\Bucket;
 
-use Behat\Transliterator\Transliterator;
 use HelloFresh\Stats\Bucket;
 
 class Plain implements Bucket
@@ -78,7 +77,7 @@ class Plain implements Bucket
         }
 
         // convert unicode symbols to ASCII
-        $asciiMetric = Transliterator::utf8ToAscii($metric);
+        $asciiMetric = transliterator_transliterate('Any-Latin; Latin-ASCII;', $metric);
         if ($asciiMetric != $metric) {
             $metric = Bucket::PREFIX_UNICODE . $asciiMetric;
         }


### PR DESCRIPTION
## Description

Since `Remove Behat/Transliterator dependency` is not compatible with PHP 7.4 and looks like the library is not actively maintained. Let's prepare for an alternative solution to adapter to 7.4 by removing this dependency