### PR TITLE
Support php 7.4

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,1 +1,0 @@
-extends: hellofresh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 
 php:
-  - '7.0'
-  - '7.1'
+  - 7.3
+  - 7.4snapshot
 
 env:
   - COMPOSER_UPDATE=

--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,14 @@
     }
   },
   "require": {
-    "php": ">= 5.6",
+    "php": ">= 7.3",
+    "ext-intl": ">= 2.0",
     "psr/http-message": "^1.0",
-    "behat/transliterator": "^1.2",
     "psr/log": "^1.0"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^2.3",
-    "phpunit/phpunit": "^5.7",
+    "friendsofphp/php-cs-fixer": "^2.16",
+    "phpunit/phpunit": "^8.4",
     "league/statsd": "^1.5"
   },
   "suggest": {

--- a/src/Bucket/Plain.php
+++ b/src/Bucket/Plain.php
@@ -1,7 +1,6 @@
 <?php
 namespace HelloFresh\Stats\Bucket;
 
-use Behat\Transliterator\Transliterator;
 use HelloFresh\Stats\Bucket;
 
 class Plain implements Bucket
@@ -78,7 +77,7 @@ class Plain implements Bucket
         }
 
         // convert unicode symbols to ASCII
-        $asciiMetric = Transliterator::utf8ToAscii($metric);
+        $asciiMetric = transliterator_transliterate('Any-Latin; Latin-ASCII;', $metric);
         if ($asciiMetric != $metric) {
             $metric = Bucket::PREFIX_UNICODE . $asciiMetric;
         }

--- a/tests/Bucket/PlainTest.php
+++ b/tests/Bucket/PlainTest.php
@@ -37,7 +37,7 @@ class PlainTest extends TestCase
     {
         $this->assertEquals('-', Plain::sanitizeMetricName(''));
 
-        $this->assertEquals('-u-iunikod', Plain::sanitizeMetricName('юникод'));
+        $this->assertEquals('-u-unikod', Plain::sanitizeMetricName('юникод'));
         $this->assertEquals('-u-Apollon', Plain::sanitizeMetricName('Ἀπόλλων'));
         $this->assertEquals('-u-acougue', Plain::sanitizeMetricName('açougue'));
 
@@ -49,7 +49,7 @@ class PlainTest extends TestCase
             Plain::sanitizeMetricName('metric.with.dots_and_underscores')
         );
 
-        $this->assertEquals('-u-iunikod_metrika', Plain::sanitizeMetricName('юникод.метрика'));
+        $this->assertEquals('-u-unikod_metrika', Plain::sanitizeMetricName('юникод.метрика'));
     }
 
     public function metrics()

--- a/tests/Client/LogTest.php
+++ b/tests/Client/LogTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class LogTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         mt_srand(time());
     }

--- a/tests/Client/MemoryTest.php
+++ b/tests/Client/MemoryTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class MemoryTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         mt_srand(time());
     }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -27,14 +27,13 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf(Client\StatsD::class, Factory::build('statsd://qwe:1234/asd', $logger));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Unknown client type
-     */
     public function testUnknownClient()
     {
         /** @var \PHPUnit_Framework_MockObject_MockObject|\Psr\Log\LoggerInterface $logger */
         $logger = $this->getMockBuilder('\Psr\Log\LoggerInterface')->getMock();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unknown client type');
 
         Factory::build(uniqid(), $logger);
     }

--- a/tests/HTTPMetricAlterCallback/HasIDAtSecondLevelTest.php
+++ b/tests/HTTPMetricAlterCallback/HasIDAtSecondLevelTest.php
@@ -64,22 +64,20 @@ class HasIDAtSecondLevelTest extends TestCase
 
     /**
      * @dataProvider createFromStringMapProvider
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid sections format
      *
      * @param string $map
      */
     public function testCreateFromStringMap_InvalidFormat($map)
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid sections format');
         HasIDAtSecondLevel::createFromStringMap($map);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Unknown section test callback name: foo
-     */
     public function testCreateFromStringMap_UnknownSectionTest()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown section test callback name: foo');
         HasIDAtSecondLevel::createFromStringMap('users:foo');
     }
 

--- a/tests/Incrementer/LogTest.php
+++ b/tests/Incrementer/LogTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 class LogTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         mt_srand(time());
     }

--- a/tests/Incrementer/MemoryTest.php
+++ b/tests/Incrementer/MemoryTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 class MemoryTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         mt_srand(time());
     }

--- a/tests/Incrementer/NoOpTest.php
+++ b/tests/Incrementer/NoOpTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 class NoOpTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         mt_srand(time());
     }

--- a/tests/Incrementer/StatsDTest.php
+++ b/tests/Incrementer/StatsDTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 class StatsDTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         mt_srand(time());
     }

--- a/tests/State/LogTest.php
+++ b/tests/State/LogTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 class LogTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         mt_srand(time());
     }

--- a/tests/State/MemoryTest.php
+++ b/tests/State/MemoryTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 class MemoryTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         mt_srand(time());
     }

--- a/tests/State/NoOpTest.php
+++ b/tests/State/NoOpTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 class NoOpTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         mt_srand(time());
     }

--- a/tests/State/StatsDTest.php
+++ b/tests/State/StatsDTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 class StatsDTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         mt_srand(time());
     }

--- a/tests/Timer/MetricTest.php
+++ b/tests/Timer/MetricTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 class MetricTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         mt_srand(time());


### PR DESCRIPTION
# Description

Add support for php 7.4 and use ext-intl instead of `behat/transliterator`