### PR TITLE
PHP 7.3+ compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: php
 
 php:
-  - '7.0'
-  - '7.1'
+  - 7.3
 
 env:
   - COMPOSER_UPDATE=

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Since version `2.x`, this library start using the built-in `intl` PHP extension 
 
 ### Version `1.x`
 
-- `php: >= 5.6`
+- `php: >= 7.0`
 - `behat/transliterator: ^1.2`
 
 ### Version `2.x`

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ dashboards to track activity and problems.
 
 ## Supported PHP versions
 
-`stats-php` version `1.x` supports the following PHP version: `7.0`, `7.1`, `7.2`. If you going to use the library with newer PHP versions - consider using version `2.x+`. 
+`stats-php` version `1.x` supports the following PHP version: `7.0`, `7.1`, `7.2`. If you going to use the library with newer PHP versions - consider using version `2.x+`.
+
+Since version `2.x`, this library start using the built-in `intl` PHP extension instead of `behat/transliterator`
 
 ## Key Features
 
@@ -28,6 +30,18 @@ dashboards to track activity and problems.
 * Fixed metric sections count for all metrics to allow easy monitoring/alerting setup in `grafana`
 * Easy to build HTTP requests metrics - timing and count
 * Generalise or modify HTTP Requests metric - e.g. skip ID part
+
+## Dependencies
+
+### Version `1.x`
+
+- `php: >= 5.6`
+- `behat/transliterator: ^1.2`
+
+### Version `2.x`
+
+- `php: >= 7.3`
+- `ext-intl: >= 2.0`
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,14 @@
     }
   },
   "require": {
-    "php": ">= 5.6",
+    "php": ">= 7.3",
+    "ext-intl": ">= 2.0",
     "psr/http-message": "^1.0",
-    "behat/transliterator": "^1.2",
     "psr/log": "^1.0"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^2.3",
-    "phpunit/phpunit": "^5.7",
+    "friendsofphp/php-cs-fixer": "^2.16",
+    "phpunit/phpunit": "^8.4",
     "league/statsd": "^1.5"
   },
   "suggest": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="true"
          stopOnFailure="false"
-         syntaxCheck="false"
          verbose="true"
 >
     <logging>

--- a/src/Bucket/Plain.php
+++ b/src/Bucket/Plain.php
@@ -1,7 +1,6 @@
 <?php
 namespace HelloFresh\Stats\Bucket;
 
-use Behat\Transliterator\Transliterator;
 use HelloFresh\Stats\Bucket;
 
 class Plain implements Bucket
@@ -78,7 +77,7 @@ class Plain implements Bucket
         }
 
         // convert unicode symbols to ASCII
-        $asciiMetric = Transliterator::utf8ToAscii($metric);
+        $asciiMetric = transliterator_transliterate('Any-Latin; Latin-ASCII;', $metric);
         if ($asciiMetric != $metric) {
             $metric = Bucket::PREFIX_UNICODE . $asciiMetric;
         }

--- a/tests/Bucket/PlainTest.php
+++ b/tests/Bucket/PlainTest.php
@@ -37,7 +37,7 @@ class PlainTest extends TestCase
     {
         $this->assertEquals('-', Plain::sanitizeMetricName(''));
 
-        $this->assertEquals('-u-iunikod', Plain::sanitizeMetricName('юникод'));
+        $this->assertEquals('-u-unikod', Plain::sanitizeMetricName('юникод'));
         $this->assertEquals('-u-Apollon', Plain::sanitizeMetricName('Ἀπόλλων'));
         $this->assertEquals('-u-acougue', Plain::sanitizeMetricName('açougue'));
 
@@ -49,7 +49,7 @@ class PlainTest extends TestCase
             Plain::sanitizeMetricName('metric.with.dots_and_underscores')
         );
 
-        $this->assertEquals('-u-iunikod_metrika', Plain::sanitizeMetricName('юникод.метрика'));
+        $this->assertEquals('-u-unikod_metrika', Plain::sanitizeMetricName('юникод.метрика'));
     }
 
     public function metrics()

--- a/tests/Client/LogTest.php
+++ b/tests/Client/LogTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class LogTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         mt_srand(time());
     }

--- a/tests/Client/MemoryTest.php
+++ b/tests/Client/MemoryTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class MemoryTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         mt_srand(time());
     }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -27,14 +27,13 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf(Client\StatsD::class, Factory::build('statsd://qwe:1234/asd', $logger));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Unknown client type
-     */
     public function testUnknownClient()
     {
         /** @var \PHPUnit_Framework_MockObject_MockObject|\Psr\Log\LoggerInterface $logger */
         $logger = $this->getMockBuilder('\Psr\Log\LoggerInterface')->getMock();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unknown client type');
 
         Factory::build(uniqid(), $logger);
     }

--- a/tests/HTTPMetricAlterCallback/HasIDAtSecondLevelTest.php
+++ b/tests/HTTPMetricAlterCallback/HasIDAtSecondLevelTest.php
@@ -64,22 +64,20 @@ class HasIDAtSecondLevelTest extends TestCase
 
     /**
      * @dataProvider createFromStringMapProvider
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid sections format
      *
      * @param string $map
      */
     public function testCreateFromStringMap_InvalidFormat($map)
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid sections format');
         HasIDAtSecondLevel::createFromStringMap($map);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Unknown section test callback name: foo
-     */
     public function testCreateFromStringMap_UnknownSectionTest()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown section test callback name: foo');
         HasIDAtSecondLevel::createFromStringMap('users:foo');
     }
 

--- a/tests/Incrementer/LogTest.php
+++ b/tests/Incrementer/LogTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 class LogTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         mt_srand(time());
     }

--- a/tests/Incrementer/MemoryTest.php
+++ b/tests/Incrementer/MemoryTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 class MemoryTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         mt_srand(time());
     }

--- a/tests/Incrementer/NoOpTest.php
+++ b/tests/Incrementer/NoOpTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 class NoOpTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         mt_srand(time());
     }

--- a/tests/Incrementer/StatsDTest.php
+++ b/tests/Incrementer/StatsDTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 class StatsDTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         mt_srand(time());
     }

--- a/tests/State/LogTest.php
+++ b/tests/State/LogTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 class LogTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         mt_srand(time());
     }

--- a/tests/State/MemoryTest.php
+++ b/tests/State/MemoryTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 class MemoryTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         mt_srand(time());
     }

--- a/tests/State/NoOpTest.php
+++ b/tests/State/NoOpTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 class NoOpTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         mt_srand(time());
     }

--- a/tests/State/StatsDTest.php
+++ b/tests/State/StatsDTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 class StatsDTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         mt_srand(time());
     }

--- a/tests/Timer/MetricTest.php
+++ b/tests/Timer/MetricTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 class MetricTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         mt_srand(time());


### PR DESCRIPTION
# Description

- Update the PHP to 7.3+
- Since `intl: >= 2.0`, We have builtin transliteration in `intl` extension. Let's use it instead of `behat/transliterator`