### PR TITLE
[FIX/PO-2958] adds all exceptions to catch block

### DIFF
--- a/src/StatsD/CachingClient.php
+++ b/src/StatsD/CachingClient.php
@@ -41,9 +41,9 @@ class CachingClient extends Client
                 $messages[] = $prefix . $key . ':' . $value;
             }
             $this->message = implode("\n", $messages);
-            @fwrite($socket, $this->message);
+            fwrite($socket, $this->message);
             fflush($socket);
-        } catch (ConnectionException $e) {
+        } catch (\Exception $e) {
             if ($this->throwConnectionExceptions) {
                 throw $e;
             } else {


### PR DESCRIPTION
Even though we post data using UDP protocol we are seeing the following error:
```
E_NOTICE fwrite(): send of 107 bytes failed with errno=111 Connection refused
```
This raises unnecessary criticals in intfood. This PR aims at adding all exceptions to be caught and prevent those criticals.