### PR TITLE
[FIX/PO-2958] silent client as the default client for statsd >v1.4

### DIFF
--- a/src/Client/StatsD.php
+++ b/src/Client/StatsD.php
@@ -5,8 +5,8 @@ use HelloFresh\Stats\Client;
 use HelloFresh\Stats\HTTPMetricAlterCallback;
 use HelloFresh\Stats\Incrementer;
 use HelloFresh\Stats\State;
+use HelloFresh\Stats\StatsD\SilentClient as StatsDClient;
 use HelloFresh\Stats\Timer;
-use League\StatsD\Client as StatsDClient;
 use League\StatsD\Exception\ConfigurationException;
 
 class StatsD extends AbstractClient implements Client

--- a/tests/Client/StatsDTest.php
+++ b/tests/Client/StatsDTest.php
@@ -53,7 +53,7 @@ class StatsDTest extends TestCase
         $statsD = new ExposedClientStatsD($dns);
         $instantiatedClient = $statsD->getClient();
 
-        $this->assertInstanceOf(Client::class, $instantiatedClient);
+        $this->assertInstanceOf(Stats\StatsD\SilentClient::class, $instantiatedClient);
     }
 
     /**
@@ -62,10 +62,10 @@ class StatsDTest extends TestCase
     public function testOptionalClientInstance()
     {
         $dns = 'statsd://stats.local:1234/prefix.ns?timeout=2.5&error=0';
-        $statsD = new ExposedClientStatsD($dns, Stats\StatsD\SilentClient::class);
+        $statsD = new ExposedClientStatsD($dns, Client::class);
         $instantiatedClient = $statsD->getClient();
 
-        $this->assertInstanceOf(Stats\StatsD\SilentClient::class, $instantiatedClient);
+        $this->assertInstanceOf(Client::class, $instantiatedClient);
     }
 
     public function testInstances()


### PR DESCRIPTION
Since the factory is built-in we can make the SilentClient the default client for 1.x versions